### PR TITLE
[Release] v1.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,9 @@ on:
   pull_request:
   # Allow this workflow to be manually dispatched.
   workflow_dispatch:
-  # Run this workflow on master daily.
+  # Run this workflow on master weekly to catch regressions from dependency or OS changes.
   schedule:
-  - cron: '0 0 * * *' # daily
+  - cron: '0 0 * * 0' # weekly, Sunday midnight
 
 # If this workflow is already running on a PR or branch, cancel it.
 concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+All notable changes to EZGL will be documented in this file.
+
+## [v1.1.0] - 2026-05-22
+
+### Added
+- PDF, PNG, and SVG export support via `print_pdf`, `print_png`, and `print_svg` on the canvas
+- Scaling factor and justification options for PNG surface exports
+- Animation support without requiring multi-threading
+- Ability to re-enter the GTK event loop after quitting
+- Ability to save graphics output without entering the event loop
+- GTK application ID option to allow multiple application instances to run simultaneously
+- `get_renderer()` and `flush_drawing()` functions on the application
+- World coordinate and visible bounds setter functions on the canvas
+- Functions to get the visible world and screen coordinates of a rectangle
+- Dialog window, message popup, label creation, and widget find/delete utility functions
+- Keyboard events are now correctly routed to the canvas (via `GtkEventBox`)
+- Background color setter for the canvas
+- Default constructors for `point2d`, `color`, and `rectangle`
+- Constructors for `application::settings`
+- Rotation angle and surface creation validation checks
+- MinGW/Windows build support
+- Support for GTK versions older than 3.20
+- HiDPI display support (surface scaling factor is now fixed to 1)
+- CI/CD pipeline using GitHub Actions, building on Ubuntu 22.04 and 24.04 in both release and debug modes
+
+### Changed
+- **Breaking**: C++ standard bumped to C++20; a C++20-compatible compiler is now required
+- **Breaking**: `get_renderer()` now returns a pointer instead of a copy, and `draw_main_canvas` passes the renderer by pointer
+- Default mouse button for canvas panning changed from right-click to left-click
+- CMake minimum version bumped from 3.0.2 to 3.10
+- `M_PI` replaced with `std::numbers::pi` (C++20)
+
+### Fixed
+- Fixed memory leaks in `basic_application`
+- Fixed spurious left-click events firing when the user pans and releases the mouse
+- Fixed user-defined mouse-press callback being suppressed while in panning mode
+- Fixed panning being artificially rate-limited to 10 Hz
+- Fixed a coordinate bug in `set_visible_world`
+- Fixed `draw_text` bounds checking to use the current coordinate system, consistent with other drawing functions
+- Fixed a justification bug in `draw_text`
+- Fixed pixel clipping for large pixel coordinates
+- Fixed non-root CMake project variable condition (`IS_ROOT_PROJECT`)
+- Fixed line drawing rendering artifacts
+- Fixed multiple compiler warnings in `graphics.cpp`, `canvas.cpp`, and `rectangle.hpp`
+
+### Infra
+- Added `.gitignore`
+- Added `.clang-format`
+- Added `CHANGELOG.md` and `RELEASE.md`
+
+## [v1.0.0] - 2019-08-19
+
+### Added
+- Initial release of EZGL
+- GTK3 and Cairo-backed application and canvas framework
+- 2D drawing primitives (lines, rectangles, arcs, text, images)
+- Camera and world-coordinate system
+- Mouse and keyboard event callbacks
+- Basic application example

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 # create the project
 project(
   ezgl
-  VERSION 1.0.1
+  VERSION 1.1.0
   LANGUAGES CXX
 )
 

--- a/README.adoc
+++ b/README.adoc
@@ -2,9 +2,9 @@
 
 image:https://codedocs.xyz/mariobadr/ezgl.svg[link="https://codedocs.xyz/mariobadr/ezgl"]
 
-EZGL is a library for use in ece297 as a simple way to create a GUI application.
-The library provides a thin wrapper around GTK and drawing functionality.
-It is also used by the VPR program.
+EZGL is a C++ graphics library that provides a thin wrapper around GTK and Cairo,
+making it easy to create GUI applications with 2D drawing support.
+It is used by the https://github.com/verilog-to-routing/vtr-verilog-to-routing[VTR project] and as a teaching tool in ECE297.
 
 == Dependencies
 
@@ -12,7 +12,7 @@ The library currently depends on GTK 3 and cairo.
 
 == Compilation
 
-This project uses CMake for compiling and works with CMake version 3.0.2 (the version available on the UG machines).
+This project uses CMake for compiling and requires CMake version 3.10 or higher.
 CMake can configure the project for different build systems and IDEs (type `cmake --help` for a list of generators available for your platform).
 We recommend you create a build directory before invoking CMake to configure the project (`cmake -B`).
 For example, we can perform the configuration step from the project root directory:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,149 @@
+# Release Process
+
+This document describes how to create a new release of EZGL.
+It is intended for project maintainers.
+
+---
+
+## Prerequisites
+
+- Maintainer access to the GitHub repository
+- Clean working tree
+- All CI checks passing on `master`
+
+---
+
+## Versioning
+
+This project follows **Semantic Versioning (SemVer)**:
+
+- **MAJOR**: incompatible API changes
+- **MINOR**: backwards-compatible new features
+- **PATCH**: backwards-compatible bug fixes
+
+Versions are prefixed with `v` in Git tags (e.g., `v1.2.3`).
+
+---
+
+## Pre-Release Checklist
+
+Before cutting a release, ensure:
+
+- [ ] CI workflow is enabled (GitHub auto-disables it after 60 days of no pushes — re-enable via the GitHub UI or the CLI)
+- [ ] All CI checks are passing on `master`
+- [ ] Smoke test passes (see [Smoke Test](#smoke-test) section below)
+- [ ] `CHANGELOG.md` contains an entry for the new version with an accurate date
+- [ ] No uncommitted changes in the working tree
+
+---
+
+## Smoke Test
+
+CI only verifies that the library compiles. Because EZGL is a graphics library, visual output
+must be checked manually by running the `basic-application` example.
+
+### Build the example
+
+```sh
+cmake -H. -Bbuild -DEZGL_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build/ --target basic-application
+cd examples/basic-application
+./basic_application
+```
+
+### What to verify
+
+The application window should open and the main canvas should display all of the following:
+
+- **Colors** — a row of filled rectangles in various named colors, plus three randomly-colored rectangles
+- **Lines** — solid, dashed, and wide lines with different line caps
+- **Arcs** — open and filled arcs, circular and elliptic
+- **Polygons** — filled triangles and quads, including semi-transparent overlapping shapes
+- **Text** — text at multiple font sizes with visible bounding boxes; text rotated at 0°, 45°, 90°, 135°, 180°, and 270°
+- **Screen coordinates** — a small red rectangle fixed to the top-left corner of the window that does not move when panning or zooming
+- **PNG image** — a small image rendered to the canvas
+
+Then exercise the interactive features in the sidebar:
+
+| Action | Expected result |
+|--------|-----------------|
+| Pan (left-click drag) | Canvas pans smoothly with no spurious clicks |
+| Scroll to zoom | Canvas zooms in/out correctly |
+| Click **Animate** | Diagonal red dashed lines animate across the canvas |
+| Click **Test** | Status bar updates to `Test Button Pressed` |
+| Change **Test Combo Box** selection | Status bar updates to the selected option (YES / NO / MAYBE) |
+| Click **Delete Combo Box** | Combo box widget is removed from the sidebar |
+| Click **Create Dialog** | A dialog window opens; accepting/rejecting/closing updates the status bar |
+| Click **Create Popup Mssg** | A popup message appears |
+| Press any key while canvas is focused | Status bar updates to `Key Pressed` |
+| Left-click on canvas | Terminal prints the click coordinates and modifier keys |
+
+---
+
+## Release Steps
+
+### 1. Update the Version Number
+
+Update the version in `CMakeLists.txt`:
+
+```cmake
+project(
+  ezgl
+  VERSION 1.2.3
+  LANGUAGES CXX
+)
+```
+
+### 2. Update the Changelog
+
+Fill in the date and finalize the entry in `CHANGELOG.md`:
+
+```md
+## [v1.2.3] - YYYY-MM-DD
+
+### Added
+- ...
+
+### Fixed
+- ...
+```
+
+### 3. Commit the Release
+
+```sh
+git commit -am "Release v1.2.3"
+```
+
+This can be in a PR, but the commit must be merged into `master` before tagging.
+
+### 4. Create and Push the Git Tag
+
+Make sure you are on a commit of `master` (i.e., you are tagging a commit that is on
+the `master` branch).
+
+```sh
+git fetch origin
+git checkout origin/master
+git tag v1.2.3
+git push --tags
+```
+
+### 5. Create the GitHub Release
+
+Go to the GitHub Releases page and draft a new release using the tag created above.
+Copy the relevant `CHANGELOG.md` section as the release description.
+
+---
+
+## Post-Release Checklist
+
+- [ ] Verify the GitHub release is published correctly
+- [ ] Announce the release to the VTR community
+
+---
+
+## Rollback Policy
+
+Git tags should **not** be deleted or recreated.
+
+If a release is faulty, issue a follow-up patch release instead.

--- a/include/ezgl/application.hpp
+++ b/include/ezgl/application.hpp
@@ -39,7 +39,9 @@
  */
 namespace ezgl {
 
-// A flag to specify whether the GUI is built from an XML file or an XML resource
+// Controls whether the GUI layout is loaded from a loose XML file on disk (true) or from a
+// compiled-in GResource (false). Defined externally by course infrastructure (ECE297) which
+// needs to swap in custom UI files at runtime; all other consumers use the compiled resource.
 #ifndef ECE297
 const bool build_ui_from_file = false;
 #else
@@ -147,7 +149,7 @@ public:
     {
       // Uniquify the application_identifier by appending a time stamp,
       // so that each instance of the same program has a different application ID.
-      // This allows multiple instances of the program to run independelty.
+      // This allows multiple instances of the program to run independently.
       application_identifier += ".t" + std::to_string(std::time(nullptr));
     }
 
@@ -161,7 +163,7 @@ public:
     {
       // Uniquify the application_identifier by appending a time stamp,
       // so that each instance of the same program has a different application ID.
-      // This allows multiple instance of the program to run independelty.
+      // This allows multiple instance of the program to run independently.
       application_identifier += ".t" + std::to_string(std::time(nullptr));
     }
   };

--- a/include/ezgl/graphics.hpp
+++ b/include/ezgl/graphics.hpp
@@ -58,7 +58,7 @@ enum t_coordinate_system {
   /**
    * Default coordinate system; specified by the user as any desired range. Graphics drawn in world coordinates
    * will be transformed to screen pixels by ezgl. Panning and zooming change the transformation from 
-   * world to screen coordinates, so they automatically work for any graphics drawn in wrld coordinates.
+   * world to screen coordinates, so they automatically work for any graphics drawn in world coordinates.
    */
   WORLD,
   /**

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -145,8 +145,7 @@ canvas *application::add_canvas(std::string const &canvas_id,
     g_warning("Canvas %s's draw callback is NULL.", canvas_id.c_str());
   }
 
-  // Can't use make_unique with protected constructor without fancy code that will confuse students, so we use new
-  // instead.
+  // Can't use make_unique with a protected constructor without overly complex workarounds, so we use new instead.
   std::unique_ptr<canvas> canvas_ptr(new canvas(canvas_id, draw_callback, coordinate_system, background_color));
   auto it = m_canvases.emplace(canvas_id, std::move(canvas_ptr));
 
@@ -475,7 +474,7 @@ void application::change_combo_box_text_options(const char* name, std::vector<st
       if(gtk_widget_get_name(widget) == name_to_find){
         auto combo_box = GTK_COMBO_BOX_TEXT(widget);
         gtk_combo_box_text_remove_all(combo_box);
-        std::cout << "REMOVED ALL" << std::endl;
+
         for(auto it : new_options){
           gtk_combo_box_text_append_text(combo_box, it.c_str());
         }

--- a/src/callback.cpp
+++ b/src/callback.cpp
@@ -133,15 +133,6 @@ gboolean move_mouse(GtkWidget *, GdkEventButton *event, gpointer data)
 
     // Check if the mouse button is pressed to support dragging
     if(g_mouse_pan.panning_mouse_button_pressed) {
-      // Code below drops a panning event if we served anothe one 
-      // less than 100 ms. I believe it was intended to avoid having panning
-      // fall behind and queue up many events if redraws were slow. However,
-      // it is not necessary on the UG machines (debian) in person, or over 
-      // VNC or on a VM and it has the bad effect of limiting refresh to 10 Hz.
-      // Commenting it out for now and will delete if there 
-      // are no reported issues. - VB
-      // if(gtk_get_current_event_time() - g_mouse_pan.last_panning_event_time < 100)
-       // return true;
 
       g_mouse_pan.last_panning_event_time = gtk_get_current_event_time();
 


### PR DESCRIPTION
Since we are moving to change the GTK backend to a QT backend, I wanted to cut a release so people would have a stable version to point to if they need to use the GTK backend.

Went through the codebase and cleaned up anything obvious and cut a new v1.1.0 release.

I also added som organization documents which will make cutting future releases easier.