### PR TITLE
ezgl: default EZGL_RHI_SAMPLE_COUNT to 1 (MSAA off) — avoids thickening 1 px net/route strokes

### DIFF
--- a/include/ezgl/qt/render_backend.hpp
+++ b/include/ezgl/qt/render_backend.hpp
@@ -36,9 +36,16 @@ enum class renderer_type { immediate, deferred, rhi };
 
 /// MSAA sample count for the rhi backend (both on-screen QRhiWidget and the
 /// offscreen render_to_image path use it; every QRhiGraphicsPipeline must
-/// match). 4x is the standard "free on modern GPUs" tier — good enough for
-/// thin diagonal lines without burning fillrate.
-inline constexpr int EZGL_RHI_SAMPLE_COUNT = 4;
+/// match). Valid Qt values are 1, 2, 4, 8, 16; 1 disables MSAA.
+///
+/// We default to 1 (MSAA off). With sample counts > 1, the multisample
+/// coverage resolve thickens 1-pixel-wide primitives: each pixel a thin
+/// diagonal line touches gets partial coverage from multiple subsamples
+/// and is blended toward the line color, so the line reads as ~2 px wide
+/// (and softer) instead of crisp 1 px. For VPR's dense net / route /
+/// channel rendering — which is dominated by 1 px strokes — that
+/// visible widening is worse than the aliasing MSAA was meant to fix.
+inline constexpr int EZGL_RHI_SAMPLE_COUNT = 1;
 
 /// Stable short name for a @ref renderer_type, suitable for log lines and
 /// test matrices.


### PR DESCRIPTION
Qt/GTK
with MSSA=4
upper frame is for Qt, bottom is GTK ref
if u zoom in upper VTR window the effect will be seen.
<img width="1920" height="2160" alt="MSSA" src="https://github.com/user-attachments/assets/79e19cf9-c7ca-4f6f-b449-5e652e1d697c" />

with no MSSA (more close to what GTK was drawn)
upper frame is for Qt, bottom is GTK ref
<img width="1920" height="2160" alt="no_MSSA" src="https://github.com/user-attachments/assets/a5abb282-f506-4477-b469-25e803907cd8" />
